### PR TITLE
refactor: altera a função de mysqli para PDO

### DIFF
--- a/includes/banco.php
+++ b/includes/banco.php
@@ -1,11 +1,22 @@
 <?php
-$banco = new mysqli("localhost", "root", "", "bd_games");
-if ($banco->connect_errno) {
-  echo "<p>Erro encontrado $banco->errno --> $banco->connect_error</p>";
-  die();
-};
 
-$banco->query("set names 'utf8'");
-$banco->query("set character_set_connection=utf8");
-$banco->query("set character_set_client=utf8");
-$banco->query("set character_set_results=utf8");
+$host = 'my_host';
+$dbName = 'my_db';
+$dbUser = 'my_user';
+$dbPassword = 'my_password';
+
+try {
+    $PDO = new PDO('mysql:host=' . $host . ';dbname=' . $dbName, $dbUser, $dbPassword);
+} catch (PDOException $e) {
+    echo 'Erro ao conectar com o MySQL: ' . $e->getMessage();
+}
+
+// $banco->query("set names 'utf8'");
+// $banco->query("set character_set_connection=utf8");
+// $banco->query("set character_set_client=utf8");
+// $banco->query("set character_set_results=utf8");
+
+$query = $PDO->query("SELECT * FROM programadores");
+$rows = $query->fetchAll();
+ 
+print_r($rows);


### PR DESCRIPTION
Dentro do PHP atual se utiliza de PDO para lidarmos com conexões MySQL,, a instância do mesmo consegue realizar querys com parâmetros "bindados", para maior segurança das suas querys.